### PR TITLE
feat : User Id와 리프레쉬 토큰을 통한 토큰 갱신/재발급 엔드포인트 생성

### DIFF
--- a/src/main/java/com/seoultech/synergybe/system/config/SecurityConfig.java
+++ b/src/main/java/com/seoultech/synergybe/system/config/SecurityConfig.java
@@ -71,6 +71,7 @@ public class SecurityConfig {
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                 .anyRequest().permitAll()
 //                .antMatchers("/swagger-ui/**").permitAll()
+//                .antMatchers("/refresh/**").permitAll() // '/refresh/{userId}' 경로에 대한 접근 허용(tokenAuthenticationFilter 회피)
 //                .antMatchers("/api/**").hasAnyAuthority(RoleType.USER.getCode())
 //                .antMatchers("/api/**/admin/**").hasAnyAuthority(RoleType.ADMIN.getCode())
 //                .anyRequest().authenticated()


### PR DESCRIPTION
## 관련 Issue
close #49 


## 변경 사항

AuthController에 기존 /refresh 로직을 참고하여 

/refresh/{userId} 엔드포인트를 신규 생성했으며 해당 메소드는 userId를 직접 요청으로부터 Path param으로 받아 토큰 로직을 수행한다.

## Todo List

- [ ] 로컬 포스트맨 테스트
- [ ] 배포 후 클라이언트와 기능 연동

